### PR TITLE
Fix broken import in src/main.py entry point

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@
 Entry point for the Wise MCP server.
 """
 
-from wise_mcp.app import app
+from wise_mcp.main import main
 
 if __name__ == "__main__":
-    app.run()
+    main()


### PR DESCRIPTION
Discovered this issue trying out Wise MCP for my business account.

## Summary
- `src/main.py` imports `app` from `wise_mcp.app`, but the object is named `mcp`
- This causes an `ImportError` when running `python src/main.py`
- Fixed by delegating to `wise_mcp.main.main()` which has the correct import and handles transport mode selection

## Test plan
- [x] Verified `python src/main.py` starts the MCP server successfully via stdio